### PR TITLE
Code size experiment

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -1,0 +1,32 @@
+use primitives::{Address, B256};
+use revm::interpreter::StateLoad;
+
+use crate::ScrollWiring;
+
+type KeccakHash = B256;
+
+pub trait ScrollCodeSizeDatabase {
+    fn code_size(&self, code_hash: KeccakHash) -> Option<usize>;
+}
+
+pub trait ScrollCodeHost {
+    fn code_size(&mut self, code_hash: Address) -> Option<(usize, bool)>;
+}
+
+impl<EvmWiringT> ScrollCodeHost for revm::Context<EvmWiringT>
+where
+    EvmWiringT: ScrollWiring,
+    EvmWiringT::Database: ScrollCodeSizeDatabase,
+{
+    fn code_size(&mut self, address: Address) -> Option<(usize, bool)> {
+        let StateLoad {
+            data: account,
+            is_cold,
+        } = self.evm.load_account(address).ok()?;
+        let code_hash = account.info.code_hash();
+        self.evm
+            .db
+            .code_size(code_hash)
+            .map(|code_size| (code_size, is_cold))
+    }
+}

--- a/src/handle_register.rs
+++ b/src/handle_register.rs
@@ -16,8 +16,9 @@ use revm::{
 use std::sync::Arc;
 
 use crate::{
-    instruction::make_scroll_instruction_tables, precompile, scroll_spec_to_generic,
-    spec::ScrollSpec, L1BlockInfo, ScrollContext, ScrollTransaction, ScrollWiring,
+    code::ScrollCodeSizeDatabase, instruction::make_scroll_instruction_tables, precompile,
+    scroll_spec_to_generic, spec::ScrollSpec, L1BlockInfo, ScrollContext, ScrollTransaction,
+    ScrollWiring,
 };
 
 /// Configure the handler for the Scroll chain.
@@ -33,6 +34,7 @@ use crate::{
 pub fn scroll_handle_register<EvmWiringT>(handler: &mut EvmHandler<'_, EvmWiringT>)
 where
     EvmWiringT: ScrollWiring,
+    EvmWiringT::Database: ScrollCodeSizeDatabase,
 {
     scroll_spec_to_generic!(handler.spec_id, {
         // Load `L1BlockInfo` from the database and invoke standard `load_accounts` handler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use revm::{primitives::Bytes, wiring::TransactionValidation};
 
+mod code;
 mod env;
 mod handle_register;
 mod instruction;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,4 +1,7 @@
-use crate::{env::TxEnv, handle_register::scroll_handle_register, ScrollContext};
+use crate::{
+    code::ScrollCodeSizeDatabase, env::TxEnv, handle_register::scroll_handle_register,
+    ScrollContext,
+};
 use core::marker::PhantomData;
 use revm::{
     database_interface::Database,
@@ -15,7 +18,7 @@ pub struct ScrollEvmWiring<DB: Database, EXT> {
     _phantom: PhantomData<(DB, EXT)>,
 }
 
-impl<DB: Database, EXT> EvmWiring for ScrollEvmWiring<DB, EXT> {
+impl<DB: Database + ScrollCodeSizeDatabase, EXT> EvmWiring for ScrollEvmWiring<DB, EXT> {
     type Block = BlockEnv;
     type Database = DB;
     type ChainContext = Context;
@@ -25,7 +28,7 @@ impl<DB: Database, EXT> EvmWiring for ScrollEvmWiring<DB, EXT> {
     type Transaction = TxEnv;
 }
 
-impl<DB: Database, EXT> revm::EvmWiring for ScrollEvmWiring<DB, EXT> {
+impl<DB: Database + ScrollCodeSizeDatabase, EXT> revm::EvmWiring for ScrollEvmWiring<DB, EXT> {
     fn handler<'evm>(hardfork: Self::Hardfork) -> revm::EvmHandler<'evm, Self> {
         let mut handler = EvmHandler::mainnet_with_spec(hardfork);
 


### PR DESCRIPTION
This is an experiment to address issue #11. The basic idea is that we will leverage the database to provide the code size to the host. This is achieved by introducing a `ScrollCodeSizeDatabase` trait which should be implemented on the database. Specifically in the case of the `stateless-block-verifier` it would be implemented on [`EvmDatabase`](https://github.com/scroll-tech/stateless-block-verifier/blob/a615e961ed6085fdc5b94cf004a6d3767084bb3d/crates/core/src/database.rs#L23-L39).