### PR TITLE
fix: return precompiles

### DIFF
--- a/src/evm.rs
+++ b/src/evm.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use revm::{
-    context::{setters::ContextSetters, ContextTr, Evm, EvmData},
+    context::{setters::ContextSetters, Cfg, ContextTr, Evm, EvmData},
     handler::{instructions::InstructionProvider, EvmTr},
     interpreter::{interpreter::EthInterpreter, Interpreter, InterpreterAction},
 };
@@ -21,10 +21,11 @@ impl<CTX: ScrollHost, INSP>
     ScrollEvm<CTX, INSP, ScrollInstructions<EthInterpreter, CTX>, ScrollPrecompileProvider<CTX>>
 {
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
+        let spec = ctx.cfg().spec();
         Self(Evm {
             data: EvmData { ctx, inspector },
             instruction: ScrollInstructions::new_mainnet(),
-            precompiles: ScrollPrecompileProvider::default(),
+            precompiles: ScrollPrecompileProvider::new_with_spec(spec),
         })
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -52,8 +52,6 @@ impl<DB, TX> IsTxError for EVMError<DB, TX> {
 ///   it can be used to calculate the L1 cost of a transaction.
 /// - `pre_execution.deduct_caller` - Overrides the logic to deduct the max transaction fee,
 ///   including the L1 fee, from the caller's balance.
-/// - `pre_execution.load_precompiles` - Overrides the logic to load the precompiles for the Scroll
-///   chain.
 /// - `post_execution.reward_beneficiary` - Overrides the logic to reward the beneficiary with the
 ///   gas fee.
 impl<EVM, ERROR, FRAME> Handler for ScrollHandler<EVM, ERROR, FRAME>


### PR DESCRIPTION
Changes to the structure and API of Revm have caused the use of `load_precompiles` to yield a Evm instance which will always have ALL precompiles active.

This is the updated flow of execution:
- Create an evm instance with [`create_evm`](https://github.com/scroll-tech/reth/blob/6ceddf476d66293ec0eaace0d7b5a7404a95eed4/crates/scroll/alloy/evm/src/lib.rs#L181).
- This returns a default `ScrollEvm` instance currently (which can also be fixed in order to return the correct spec directly), which uses the [default precompiles](https://github.com/scroll-tech/scroll-revm/blob/main/src/precompile/mod.rs#L115) i.e. precompiles for the latest spec.
- The precompiles are later on set to the correct spec [during execution](https://github.com/bluealloy/revm/blob/2e5b118a5843576d5b7230e4bb2a0bf82abc8ac8/crates/handler/src/frame.rs#L533), with [`set_spec`](https://github.com/scroll-tech/scroll-revm/blob/main/src/precompile/mod.rs#L88).

Because of the way we loaded the precompiles using a static variable, the precompiles would get loaded with the latest spec, but never set to the correct spec because the `OnceBox` was already set.