### PR TITLE
feat: euclid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ name = "revm-scroll"
 version = "0.1.0"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "enumn",
  "once_cell",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ revm-inspector = { version = "3.0.0", default-features = false }
 
 # misc
 auto_impl = "1.2.0"
+derive-where = { version = "1.2.7", default-features = false }
 enumn = { version = "0.1" }
 once_cell = { version = "1.19", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # revm
-revm = { version = "22.0.0", default-features = false }
+revm = { version = "22.0.0", default-features = false, features = ["secp256r1"] }
 revm-primitives = { version = "18.0.0", default-features = false }
 revm-inspector = { version = "3.0.0", default-features = false }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -49,7 +49,7 @@ where
     }
 }
 
-/// Allows to build a default Scroll [`Context`].
+/// Allows to build a default [`ScrollContextFull`].
 pub trait DefaultScrollContext {
     fn scroll() -> ScrollContext<EmptyDB>;
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,321 @@
+use crate::{journal::ScrollJournal, ScrollSpecId};
+
+use derive_where::derive_where;
+use revm::{
+    context::{
+        Block, BlockEnv, Cfg, CfgEnv, ContextSetters, ContextTr, JournalTr, Transaction, TxEnv,
+    },
+    context_interface::context::ContextError,
+    database::EmptyDB,
+    Context, Database, MainContext,
+};
+
+/// Wraps a [`Context`] to correctly set the [`ScrollJournal`]'s spec.
+#[derive_where(Clone, Debug; BLOCK, CFG, CHAIN, TX, DB, <DB as Database>::Error)]
+pub struct ScrollContextFull<
+    BLOCK = BlockEnv,
+    TX = TxEnv,
+    CFG = CfgEnv<ScrollSpecId>,
+    DB: Database = EmptyDB,
+    CHAIN = (),
+> {
+    pub inner: Context<BLOCK, TX, CFG, DB, ScrollJournal<DB>, CHAIN>,
+}
+
+impl<BLOCK: Block, TX: Transaction, DB: Database, CFG: Cfg, CHAIN> ContextTr
+    for ScrollContextFull<BLOCK, TX, CFG, DB, CHAIN>
+{
+    type Block = BLOCK;
+    type Tx = TX;
+    type Cfg = CFG;
+    type Db = DB;
+    type Journal = ScrollJournal<DB>;
+    type Chain = CHAIN;
+
+    fn tx(&self) -> &Self::Tx {
+        &self.inner.tx
+    }
+
+    fn block(&self) -> &Self::Block {
+        &self.inner.block
+    }
+
+    fn cfg(&self) -> &Self::Cfg {
+        &self.inner.cfg
+    }
+
+    fn journal(&mut self) -> &mut Self::Journal {
+        &mut self.inner.journaled_state
+    }
+
+    fn journal_ref(&self) -> &Self::Journal {
+        &self.inner.journaled_state
+    }
+
+    fn db(&mut self) -> &mut Self::Db {
+        self.inner.journaled_state.db()
+    }
+
+    fn db_ref(&self) -> &Self::Db {
+        self.inner.journaled_state.db_ref()
+    }
+
+    fn chain(&mut self) -> &mut Self::Chain {
+        &mut self.inner.chain
+    }
+
+    fn error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>> {
+        &mut self.inner.error
+    }
+
+    fn tx_journal(&mut self) -> (&mut Self::Tx, &mut Self::Journal) {
+        (&mut self.inner.tx, &mut self.inner.journaled_state)
+    }
+
+    // Keep Default Implementation for Instructions Host Interface
+}
+
+impl<BLOCK: Block, TX: Transaction, DB: Database, CFG: Cfg, CHAIN> ContextSetters
+    for ScrollContextFull<BLOCK, TX, CFG, DB, CHAIN>
+{
+    fn set_tx(&mut self, tx: Self::Tx) {
+        self.inner.tx = tx;
+    }
+
+    fn set_block(&mut self, block: Self::Block) {
+        self.inner.block = block;
+    }
+}
+
+impl MainContext for ScrollContextFull {
+    fn mainnet() -> Self {
+        ScrollContextFull::new(EmptyDB::new(), ScrollSpecId::default())
+    }
+}
+
+impl<BLOCK: Block + Default, TX: Transaction + Default, DB: Database, CHAIN: Default>
+    ScrollContextFull<BLOCK, TX, CfgEnv<ScrollSpecId>, DB, CHAIN>
+{
+    /// Returns a new [`ScrollContextFull`] from the provided database and spec id.
+    pub fn new(db: DB, spec: ScrollSpecId) -> Self {
+        let mut journaled_state = ScrollJournal::new(db);
+        journaled_state.set_spec_id(spec.into());
+        journaled_state.set_scroll_spec_id(spec);
+
+        let mut cfg = CfgEnv::default();
+        cfg.spec = spec;
+
+        Self {
+            inner: Context {
+                tx: TX::default(),
+                block: BLOCK::default(),
+                cfg,
+                journaled_state,
+                chain: Default::default(),
+                error: Ok(()),
+            },
+        }
+    }
+}
+
+impl<BLOCK, TX, CFG, DB, CHAIN> ScrollContextFull<BLOCK, TX, CFG, DB, CHAIN>
+where
+    BLOCK: Block,
+    TX: Transaction,
+    CFG: Cfg<Spec = ScrollSpecId>,
+    DB: Database,
+{
+    pub fn with_new_journal(
+        self,
+        mut journal: ScrollJournal<DB>,
+    ) -> ScrollContextFull<BLOCK, TX, CFG, DB, CHAIN> {
+        journal.set_spec_id(self.inner.cfg.spec().into());
+        journal.set_scroll_spec_id(self.inner.cfg.spec());
+
+        ScrollContextFull {
+            inner: Context {
+                tx: self.inner.tx,
+                block: self.inner.block,
+                cfg: self.inner.cfg,
+                journaled_state: journal,
+                chain: self.inner.chain,
+                error: Ok(()),
+            },
+        }
+    }
+
+    /// Creates a new context with a new database type.
+    ///
+    /// This will create a new [`ScrollJournal`] object.
+    pub fn with_db<ODB: Database>(self, db: ODB) -> ScrollContextFull<BLOCK, TX, CFG, ODB, CHAIN> {
+        let spec = self.inner.cfg.spec();
+        let mut journaled_state = ScrollJournal::new(db);
+        journaled_state.set_spec_id(spec.into());
+        journaled_state.set_scroll_spec_id(spec);
+
+        ScrollContextFull {
+            inner: Context {
+                tx: self.inner.tx,
+                block: self.inner.block,
+                cfg: self.inner.cfg,
+                journaled_state,
+                chain: self.inner.chain,
+                error: Ok(()),
+            },
+        }
+    }
+
+    /// Creates a new context with a new block type.
+    pub fn with_block<OB: Block>(self, block: OB) -> ScrollContextFull<OB, TX, CFG, DB, CHAIN> {
+        ScrollContextFull {
+            inner: Context {
+                tx: self.inner.tx,
+                block,
+                cfg: self.inner.cfg,
+                journaled_state: self.inner.journaled_state,
+                chain: self.inner.chain,
+                error: Ok(()),
+            },
+        }
+    }
+    /// Creates a new context with a new transaction type.
+    pub fn with_tx<OTX: Transaction>(
+        self,
+        tx: OTX,
+    ) -> ScrollContextFull<BLOCK, OTX, CFG, DB, CHAIN> {
+        ScrollContextFull {
+            inner: Context {
+                tx,
+                block: self.inner.block,
+                cfg: self.inner.cfg,
+                journaled_state: self.inner.journaled_state,
+                chain: self.inner.chain,
+                error: Ok(()),
+            },
+        }
+    }
+
+    /// Creates a new context with a new chain type.
+    pub fn with_chain<OC>(self, chain: OC) -> ScrollContextFull<BLOCK, TX, CFG, DB, OC> {
+        ScrollContextFull {
+            inner: Context {
+                tx: self.inner.tx,
+                block: self.inner.block,
+                cfg: self.inner.cfg,
+                journaled_state: self.inner.journaled_state,
+                chain,
+                error: Ok(()),
+            },
+        }
+    }
+
+    /// Creates a new context with a new chain type.
+    pub fn with_cfg<OCFG: Cfg<Spec = ScrollSpecId>>(
+        mut self,
+        cfg: OCFG,
+    ) -> ScrollContextFull<BLOCK, TX, OCFG, DB, CHAIN> {
+        self.inner.journaled_state.set_spec_id(cfg.spec().into());
+        self.inner.journaled_state.set_scroll_spec_id(cfg.spec());
+
+        ScrollContextFull {
+            inner: Context {
+                tx: self.inner.tx,
+                block: self.inner.block,
+                cfg,
+                journaled_state: self.inner.journaled_state,
+                chain: self.inner.chain,
+                error: Ok(()),
+            },
+        }
+    }
+
+    /// Modifies the context configuration.
+    #[must_use]
+    pub fn modify_cfg_chained<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut CFG),
+    {
+        f(&mut self.inner.cfg);
+        self.inner.journaled_state.set_spec_id(self.inner.cfg.spec().into());
+        self.inner.journaled_state.set_scroll_spec_id(self.inner.cfg.spec());
+        self
+    }
+
+    /// Modifies the context block.
+    #[must_use]
+    pub fn modify_block_chained<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut BLOCK),
+    {
+        self.modify_block(f);
+        self
+    }
+
+    /// Modifies the context transaction.
+    #[must_use]
+    pub fn modify_tx_chained<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut TX),
+    {
+        self.modify_tx(f);
+        self
+    }
+
+    /// Modifies the context chain.
+    #[must_use]
+    pub fn modify_chain_chained<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut CHAIN),
+    {
+        self.modify_chain(f);
+        self
+    }
+
+    /// Modifies the context database.
+    #[must_use]
+    pub fn modify_db_chained<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut DB),
+    {
+        self.modify_db(f);
+        self
+    }
+
+    /// Modifies the context block.
+    pub fn modify_block<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut BLOCK),
+    {
+        f(&mut self.inner.block);
+    }
+
+    pub fn modify_tx<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut TX),
+    {
+        f(&mut self.inner.tx);
+    }
+
+    pub fn modify_cfg<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut CFG),
+    {
+        f(&mut self.inner.cfg);
+        self.inner.journaled_state.set_spec_id(self.inner.cfg.spec().into());
+        self.inner.journaled_state.set_scroll_spec_id(self.inner.cfg.spec());
+    }
+
+    pub fn modify_chain<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut CHAIN),
+    {
+        f(&mut self.inner.chain);
+    }
+
+    pub fn modify_db<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut DB),
+    {
+        f(self.inner.journaled_state.db());
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,5 @@
 use crate::{journal::ScrollJournal, ScrollSpecId};
+use core::ops::{Deref, DerefMut};
 
 use derive_where::derive_where;
 use revm::{
@@ -20,6 +21,22 @@ pub struct ScrollContextFull<
     CHAIN = (),
 > {
     pub inner: Context<BLOCK, TX, CFG, DB, ScrollJournal<DB>, CHAIN>,
+}
+
+impl<BLOCK, TX, CFG, DB: Database, CHAIN> Deref for ScrollContextFull<BLOCK, TX, CFG, DB, CHAIN> {
+    type Target = Context<BLOCK, TX, CFG, DB, ScrollJournal<DB>, CHAIN>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<BLOCK, TX, CFG, DB: Database, CHAIN> DerefMut
+    for ScrollContextFull<BLOCK, TX, CFG, DB, CHAIN>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
 }
 
 impl<BLOCK: Block, TX: Transaction, DB: Database, CFG: Cfg, CHAIN> ContextTr

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,7 +1,7 @@
 //! Handler related to Scroll chain.
 
 use crate::{exec::ScrollContextTr, l1block::L1BlockInfo, transaction::ScrollTxTr, ScrollSpecId};
-use std::string::ToString;
+use std::{boxed::Box, string::ToString};
 
 use revm::{
     bytecode::Bytecode,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -468,7 +468,7 @@ mod tests {
         l1block::L1_GAS_PRICE_ORACLE_ADDRESS,
         transaction::L1_MESSAGE_TYPE,
     };
-    use std::boxed::Box;
+    use std::{boxed::Box, vec};
 
     use revm::{
         context::transaction::{Authorization, SignedAuthorization},

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -6,9 +6,10 @@ use revm::{
         JournalOutput, JournalTr,
     },
     interpreter::{SStoreResult, SelfDestructResult, StateLoad},
-    state::Account,
-    Database, Journal,
+    state::{Account, EvmState},
+    Database, Journal, JournalEntry,
 };
+use revm_inspector::JournalExt;
 use revm_primitives::{hardfork::SpecId, Address, HashSet, Log, B256, U256};
 
 /// A wrapper around the default Journal.
@@ -16,9 +17,9 @@ use revm_primitives::{hardfork::SpecId, Address, HashSet, Log, B256, U256};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollJournal<DB> {
     /// The inner journal.
-    inner: Journal<DB>,
+    pub inner: Journal<DB>,
     /// The spec id.
-    spec_id: ScrollSpecId,
+    pub spec_id: ScrollSpecId,
 }
 
 impl<DB> ScrollJournal<DB> {
@@ -200,6 +201,24 @@ impl<DB: Database> JournalTr for ScrollJournal<DB> {
 
     fn finalize(&mut self) -> Self::FinalOutput {
         JournalTr::finalize(&mut self.inner)
+    }
+}
+
+impl<DB: Database> JournalExt for ScrollJournal<DB> {
+    fn logs(&self) -> &[Log] {
+        JournalExt::logs(&self.inner)
+    }
+
+    fn last_journal(&self) -> &[JournalEntry] {
+        JournalExt::last_journal(&self.inner)
+    }
+
+    fn evm_state(&self) -> &EvmState {
+        JournalExt::evm_state(&self.inner)
+    }
+
+    fn evm_state_mut(&mut self) -> &mut EvmState {
+        JournalExt::evm_state_mut(&mut self.inner)
     }
 }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -206,6 +206,8 @@ impl<DB: Database> JournalTr for ScrollJournal<DB> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::boxed::Box;
+
     use revm::database::EmptyDB;
     use revm_primitives::{address, bytes};
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,0 +1,204 @@
+use crate::ScrollSpecId;
+use revm::{
+    bytecode::Bytecode,
+    context::{
+        journaled_state::{AccountLoad, JournalCheckpoint, TransferError},
+        JournalOutput, JournalTr,
+    },
+    interpreter::{SStoreResult, SelfDestructResult, StateLoad},
+    state::Account,
+    Database, Journal,
+};
+use revm_primitives::{hardfork::SpecId, Address, HashSet, Log, B256, U256};
+
+/// A wrapper around the default Journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScrollJournal<DB> {
+    /// The inner journal.
+    inner: Journal<DB>,
+    /// The spec id.
+    spec_id: ScrollSpecId,
+}
+
+impl<DB> ScrollJournal<DB> {
+    pub fn set_scroll_spec_id(&mut self, scroll_spec_id: ScrollSpecId) {
+        self.spec_id = scroll_spec_id
+    }
+}
+
+impl<DB: Database> JournalTr for ScrollJournal<DB> {
+    type Database = DB;
+    type FinalOutput = JournalOutput;
+
+    fn new(database: Self::Database) -> Self {
+        Self { inner: Journal::new(database), spec_id: ScrollSpecId::default() }
+    }
+
+    fn db_ref(&self) -> &Self::Database {
+        self.inner.db_ref()
+    }
+
+    fn db(&mut self) -> &mut Self::Database {
+        self.inner.db()
+    }
+
+    fn sload(
+        &mut self,
+        address: Address,
+        key: U256,
+    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error> {
+        JournalTr::sload(&mut self.inner, address, key)
+    }
+
+    fn sstore(
+        &mut self,
+        address: Address,
+        key: U256,
+        value: U256,
+    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
+        JournalTr::sstore(&mut self.inner, address, key, value)
+    }
+
+    fn tload(&mut self, address: Address, key: U256) -> U256 {
+        JournalTr::tload(&mut self.inner, address, key)
+    }
+
+    fn tstore(&mut self, address: Address, key: U256, value: U256) {
+        JournalTr::tstore(&mut self.inner, address, key, value)
+    }
+
+    fn log(&mut self, log: Log) {
+        JournalTr::log(&mut self.inner, log)
+    }
+
+    fn selfdestruct(
+        &mut self,
+        address: Address,
+        target: Address,
+    ) -> Result<StateLoad<SelfDestructResult>, <Self::Database as Database>::Error> {
+        JournalTr::selfdestruct(&mut self.inner, address, target)
+    }
+
+    fn warm_account_and_storage(
+        &mut self,
+        address: Address,
+        storage_keys: impl IntoIterator<Item = U256>,
+    ) -> Result<(), <Self::Database as Database>::Error> {
+        JournalTr::warm_account_and_storage(&mut self.inner, address, storage_keys)
+    }
+
+    fn warm_account(&mut self, address: Address) {
+        JournalTr::warm_account(&mut self.inner, address)
+    }
+
+    fn warm_precompiles(&mut self, addresses: HashSet<Address>) {
+        JournalTr::warm_precompiles(&mut self.inner, addresses)
+    }
+
+    fn precompile_addresses(&self) -> &HashSet<Address> {
+        JournalTr::precompile_addresses(&self.inner)
+    }
+
+    fn set_spec_id(&mut self, spec_id: SpecId) {
+        JournalTr::set_spec_id(&mut self.inner, spec_id)
+    }
+
+    fn touch_account(&mut self, address: Address) {
+        JournalTr::touch_account(&mut self.inner, address)
+    }
+
+    fn transfer(
+        &mut self,
+        from: Address,
+        to: Address,
+        balance: U256,
+    ) -> Result<Option<TransferError>, <Self::Database as Database>::Error> {
+        JournalTr::transfer(&mut self.inner, from, to, balance)
+    }
+
+    fn inc_account_nonce(
+        &mut self,
+        address: Address,
+    ) -> Result<Option<u64>, <Self::Database as Database>::Error> {
+        JournalTr::inc_account_nonce(&mut self.inner, address)
+    }
+
+    fn load_account(
+        &mut self,
+        address: Address,
+    ) -> Result<StateLoad<&mut Account>, <Self::Database as Database>::Error> {
+        JournalTr::load_account(&mut self.inner, address)
+    }
+
+    fn load_account_code(
+        &mut self,
+        address: Address,
+    ) -> Result<StateLoad<&mut Account>, <Self::Database as Database>::Error> {
+        JournalTr::load_account_code(&mut self.inner, address)
+    }
+
+    fn load_account_delegated(
+        &mut self,
+        address: Address,
+    ) -> Result<StateLoad<AccountLoad>, <Self::Database as Database>::Error> {
+        let spec = self.spec_id;
+        let is_eip7702_enabled = spec.is_enabled_in(ScrollSpecId::EUCLID);
+        let db = &mut self.inner.database;
+
+        let account = self.inner.inner.load_account_optional(db, address, is_eip7702_enabled)?;
+        let is_empty = account.state_clear_aware_is_empty(spec.into());
+
+        let mut account_load = StateLoad::new(
+            AccountLoad { is_delegate_account_cold: None, is_empty },
+            account.is_cold,
+        );
+
+        // load delegate code if account is EIP-7702
+        if let Some(Bytecode::Eip7702(code)) = &account.info.code {
+            let address = code.address();
+            let delegate_account = self.inner.inner.load_account(db, address)?;
+            account_load.data.is_delegate_account_cold = Some(delegate_account.is_cold);
+        }
+
+        Ok(account_load)
+    }
+
+    fn set_code_with_hash(&mut self, address: Address, code: Bytecode, hash: B256) {
+        JournalTr::set_code_with_hash(&mut self.inner, address, code, hash)
+    }
+
+    fn clear(&mut self) {
+        JournalTr::clear(&mut self.inner)
+    }
+
+    fn checkpoint(&mut self) -> JournalCheckpoint {
+        JournalTr::checkpoint(&mut self.inner)
+    }
+
+    fn checkpoint_commit(&mut self) {
+        JournalTr::checkpoint_commit(&mut self.inner)
+    }
+
+    fn checkpoint_revert(&mut self, checkpoint: JournalCheckpoint) {
+        JournalTr::checkpoint_revert(&mut self.inner, checkpoint)
+    }
+
+    fn create_account_checkpoint(
+        &mut self,
+        caller: Address,
+        address: Address,
+        balance: U256,
+        spec_id: SpecId,
+    ) -> Result<JournalCheckpoint, TransferError> {
+        JournalTr::create_account_checkpoint(&mut self.inner, caller, address, balance, spec_id)
+    }
+
+    fn depth(&self) -> usize {
+        JournalTr::depth(&self.inner)
+    }
+
+    fn finalize(&mut self) -> Self::FinalOutput {
+        JournalTr::finalize(&mut self.inner)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,16 @@ extern crate alloc as std;
 
 pub mod builder;
 
+pub mod context;
+
 pub use evm::ScrollEvm;
 pub mod evm;
 
 mod exec;
 
 pub mod handler;
+
+pub mod journal;
 
 pub mod instructions;
 

--- a/src/precompile/mod.rs
+++ b/src/precompile/mod.rs
@@ -6,7 +6,7 @@ use revm::{
     context::{Cfg, ContextTr},
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{InputsImpl, InterpreterResult},
-    precompile::{self, PrecompileError, PrecompileWithAddress, Precompiles},
+    precompile::{self, secp256r1, PrecompileError, PrecompileWithAddress, Precompiles},
     primitives::{Address, Bytes},
 };
 use revm_primitives::hardfork::SpecId;
@@ -29,6 +29,7 @@ impl ScrollPrecompileProvider {
         let precompiles = match spec {
             ScrollSpecId::SHANGHAI => pre_bernoulli(),
             ScrollSpecId::BERNOULLI | ScrollSpecId::CURIE | ScrollSpecId::DARWIN => bernoulli(),
+            ScrollSpecId::EUCLID => euclid(),
         };
         Self { precompile_provider: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
     }
@@ -70,6 +71,16 @@ pub(crate) fn bernoulli() -> &'static Precompiles {
     INSTANCE.get_or_init(|| {
         let mut precompiles = pre_bernoulli().clone();
         precompiles.extend([hash::sha256::SHA256_BERNOULLI]);
+        Box::new(precompiles)
+    })
+}
+
+/// Returns precompiles for Euclid spec.
+pub(crate) fn euclid() -> &'static Precompiles {
+    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+    INSTANCE.get_or_init(|| {
+        let mut precompiles = bernoulli().clone();
+        precompiles.extend([secp256r1::P256VERIFY]);
         Box::new(precompiles)
     })
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -7,8 +7,9 @@ pub enum ScrollSpecId {
     SHANGHAI = 1,
     BERNOULLI = 2,
     CURIE = 3,
-    #[default]
     DARWIN = 4,
+    #[default]
+    EUCLID = 5,
 }
 
 impl ScrollSpecId {
@@ -33,7 +34,9 @@ impl ScrollSpecId {
     /// Converts the `ScrollSpecId` to a `SpecId`.
     const fn into_eth_spec_id(self) -> SpecId {
         match self {
-            Self::SHANGHAI | Self::BERNOULLI | Self::CURIE | Self::DARWIN => SpecId::SHANGHAI,
+            Self::SHANGHAI | Self::BERNOULLI | Self::CURIE | Self::DARWIN | Self::EUCLID => {
+                SpecId::SHANGHAI
+            }
         }
     }
 }
@@ -52,6 +55,7 @@ pub mod name {
     pub const BERNOULLI: &str = "bernoulli";
     pub const CURIE: &str = "curie";
     pub const DARWIN: &str = "darwin";
+    pub const EUCLID: &str = "euclid";
 }
 
 impl From<&str> for ScrollSpecId {
@@ -61,6 +65,7 @@ impl From<&str> for ScrollSpecId {
             name::BERNOULLI => Self::BERNOULLI,
             name::CURIE => Self::CURIE,
             name::DARWIN => Self::DARWIN,
+            name::EUCLID => Self::EUCLID,
             _ => Self::default(),
         }
     }
@@ -73,6 +78,7 @@ impl From<ScrollSpecId> for &'static str {
             ScrollSpecId::BERNOULLI => name::BERNOULLI,
             ScrollSpecId::CURIE => name::CURIE,
             ScrollSpecId::DARWIN => name::DARWIN,
+            ScrollSpecId::EUCLID => name::EUCLID,
         }
     }
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -2,6 +2,7 @@ use revm_primitives::hardfork::SpecId;
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, enumn::N)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_camel_case_types)]
 pub enum ScrollSpecId {
     SHANGHAI = 1,


### PR DESCRIPTION
This PR updates the codebase in order to be compatible with the Euclid hardfork by:
- Modifying the `Handler` in order to include EIP-7702 code.
- Adds custom `ScrollContext` and `ScrollJournal` implementations in order to correctly track the current Scroll hardfork and add a custom implementation of the `load_account_delegated`.