### PR TITLE
feat: bump revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,15 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -619,11 +610,10 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
+checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
 dependencies = [
- "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -745,17 +735,6 @@ name = "derive-where"
 version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1373,6 +1352,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,8 +1792,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "revm"
-version = "22.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "23.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -1810,10 +1810,11 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "3.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "bitvec",
+ "once_cell",
  "phf",
  "revm-primitives",
  "serde",
@@ -1821,8 +1822,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "3.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -1836,12 +1837,13 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "3.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
+ "either",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
@@ -1850,8 +1852,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "3.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -1863,8 +1865,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "3.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -1874,8 +1876,8 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "3.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -1891,8 +1893,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "3.0.1"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -1907,8 +1909,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "18.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "19.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -1918,8 +1920,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "19.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "20.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1943,11 +1945,11 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "18.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "19.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "alloy-primitives",
- "enumn",
+ "num_enum",
  "serde",
 ]
 
@@ -1966,8 +1968,8 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "3.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#5a4b0594161975e3e711a681809b7d710f2c0fec"
+version = "4.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
 dependencies = [
  "bitflags",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "feat/
 revm-inspector = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth", default-features = false }
 
 # misc
-auto_impl = "1.2.0"
+auto_impl = "1.3.0"
 enumn = { version = "0.1" }
 once_cell = { version = "1.19", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -49,11 +49,11 @@ where
     type Block = <CTX as ContextTr>::Block;
 
     fn set_tx(&mut self, tx: Self::Tx) {
-        self.0.data.ctx.set_tx(tx);
+        self.0.ctx.set_tx(tx);
     }
 
     fn set_block(&mut self, block: Self::Block) {
-        self.0.data.ctx.set_block(block);
+        self.0.ctx.set_block(block);
     }
 
     fn replay(&mut self) -> Self::Output {
@@ -89,7 +89,7 @@ where
     type Inspector = INSP;
 
     fn set_inspector(&mut self, inspector: Self::Inspector) {
-        self.0.data.inspector = inspector;
+        self.0.inspector = inspector;
     }
 
     fn inspect_replay(&mut self) -> Self::Output {

--- a/src/precompile/bn128.rs
+++ b/src/precompile/bn128.rs
@@ -6,7 +6,7 @@ use revm::{
         },
         u64_to_address, PrecompileError, PrecompileResult, PrecompileWithAddress,
     },
-    primitives::{Address, Bytes},
+    primitives::Address,
 };
 
 pub mod pair {
@@ -42,7 +42,7 @@ pub mod pair {
     /// # Errors
     /// - `PrecompileError::Other("BN128PairingInputOverflow: input overflow".into())` if the input
     ///   length is greater than 768 bytes.
-    fn bernoulli_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    fn bernoulli_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if input.len() > N_PAIRING_PER_OP * N_BYTES_PER_PAIR {
             return Err(PrecompileError::Other("BN128PairingInputOverflow: input overflow".into()));
         }

--- a/src/precompile/mod.rs
+++ b/src/precompile/mod.rs
@@ -7,7 +7,7 @@ use revm::{
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{InputsImpl, InterpreterResult},
     precompile::{self, secp256r1, PrecompileError, PrecompileWithAddress, Precompiles},
-    primitives::{Address, Bytes},
+    primitives::Address,
 };
 use revm_primitives::hardfork::SpecId;
 
@@ -33,12 +33,18 @@ impl ScrollPrecompileProvider {
         };
         Self { precompile_provider: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
     }
+
+    /// Precompiles getter.
+    #[inline]
+    pub fn precompiles(&self) -> &'static Precompiles {
+        self.precompile_provider.precompiles
+    }
 }
 
 /// A helper function that creates a precompile that returns `PrecompileError::Other("Precompile not
 /// implemented".into())` for a given address.
 const fn precompile_not_implemented(address: Address) -> PrecompileWithAddress {
-    PrecompileWithAddress(address, |_input: &Bytes, _gas_limit: u64| {
+    PrecompileWithAddress(address, |_input: &[u8], _gas_limit: u64| {
         Err(PrecompileError::Other("NotImplemented: Precompile not implemented".into()))
     })
 }

--- a/src/precompile/modexp.rs
+++ b/src/precompile/modexp.rs
@@ -5,7 +5,7 @@ use revm::{
         utilities::right_pad_with_offset,
         PrecompileError, PrecompileResult, PrecompileWithAddress,
     },
-    primitives::{Address, Bytes, U256},
+    primitives::{Address, U256},
 };
 
 // CONSTANTS
@@ -36,7 +36,7 @@ pub const BERNOULLI: PrecompileWithAddress =
 ///   length is greater than 32 bytes.
 /// - `PrecompileError::Other("ModexpModOverflow: modexp mod overflow".into())` if the modulus
 ///   length is greater than 32 bytes.
-fn bernoulli_run(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+fn bernoulli_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let base_len = U256::from_be_bytes(right_pad_with_offset::<32>(input, 0).into_owned());
     let exp_len = U256::from_be_bytes(right_pad_with_offset::<32>(input, 32).into_owned());
     let mod_len = U256::from_be_bytes(right_pad_with_offset::<32>(input, 64).into_owned());

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -36,8 +36,14 @@ impl Default for ScrollTransaction<TxEnv> {
 }
 
 impl<T: Transaction> Transaction for ScrollTransaction<T> {
-    type AccessListItem = T::AccessListItem;
-    type Authorization = T::Authorization;
+    type AccessListItem<'a>
+        = T::AccessListItem<'a>
+    where
+        T: 'a;
+    type Authorization<'a>
+        = T::Authorization<'a>
+    where
+        T: 'a;
 
     fn tx_type(&self) -> u8 {
         self.base.tx_type()
@@ -75,7 +81,7 @@ impl<T: Transaction> Transaction for ScrollTransaction<T> {
         self.base.gas_price()
     }
 
-    fn access_list(&self) -> Option<impl Iterator<Item = &Self::AccessListItem>> {
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>> {
         self.base.access_list()
     }
 
@@ -91,7 +97,7 @@ impl<T: Transaction> Transaction for ScrollTransaction<T> {
         self.base.authorization_list_len()
     }
 
-    fn authorization_list(&self) -> impl Iterator<Item = &Self::Authorization> {
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>> {
         self.base.authorization_list()
     }
 


### PR DESCRIPTION
Bumps the [revm](https://github.com/scroll-tech/revm/commit/ffd145a9df51113db02b3d35a6e8b87bbf9b38d8) dep to 23.0.1. 

Major changes:
- `validate_tx_against_state` and `deduct_caller` were merged into a single function in the `Handler`. The following rules need to be maintained for L1 messages: caller is not deducted and balance is only checked for L1 messages pre-Euclid.