### PR TITLE
fix: transaction pre execution

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -79,7 +79,13 @@ where
             *evm.ctx().chain() = l1_block_info;
         }
 
-        self.mainnet.pre_execution(evm)
+        self.validate_against_state_and_deduct_caller(evm)?;
+        self.load_accounts(evm)?;
+        // Cache EIP-7873 EOF initcodes and calculate its hash. Does nothing if not Initcode
+        // Transaction.
+        self.apply_eip7873_eof_initcodes(evm)?;
+        let gas = self.apply_eip7702_auth_list(evm)?;
+        Ok(gas)
     }
 
     #[inline]
@@ -310,6 +316,18 @@ mod tests {
             })
     }
 
+    fn context_with_funds(funds: U256) -> ScrollContext<InMemoryDB> {
+        context().modify_db_chained(|db| {
+            db.cache.accounts.insert(
+                CALLER,
+                DbAccount {
+                    info: AccountInfo { balance: funds, ..Default::default() },
+                    ..Default::default()
+                },
+            );
+        })
+    }
+
     #[test]
     fn test_validate_lacking_funds() -> Result<(), Box<dyn core::error::Error>> {
         let ctx = context();
@@ -398,10 +416,10 @@ mod tests {
 
     #[test]
     fn test_load_account() -> Result<(), Box<dyn core::error::Error>> {
-        let ctx = context();
+        let ctx = context_with_funds(MIN_TRANSACTION_COST + L1_DATA_COST);
         let mut evm = ctx.build_scroll();
         let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_, _, _>>::new();
-        handler.load_accounts(&mut evm)?;
+        handler.pre_execution(&mut evm)?;
 
         let l1_block_info = evm.ctx().chain.clone();
         assert_ne!(l1_block_info, L1BlockInfo::default());
@@ -438,23 +456,11 @@ mod tests {
 
     #[test]
     fn test_deduct_caller() -> Result<(), Box<dyn core::error::Error>> {
-        let ctx = context().modify_db_chained(|db| {
-            db.cache.accounts.insert(
-                CALLER,
-                DbAccount {
-                    info: AccountInfo {
-                        balance: MIN_TRANSACTION_COST + L1_DATA_COST,
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            );
-        });
+        let ctx = context_with_funds(MIN_TRANSACTION_COST + L1_DATA_COST);
 
         let mut evm = ctx.build_scroll();
         let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_, _, _>>::new();
-        handler.load_accounts(&mut evm)?;
-        handler.validate_against_state_and_deduct_caller(&mut evm)?;
+        handler.pre_execution(&mut evm)?;
 
         let caller_account = evm.ctx().journal().load_account(CALLER)?;
         assert_eq!(caller_account.info.balance, U256::ZERO);
@@ -579,7 +585,7 @@ mod tests {
 
     #[test]
     fn test_reward_beneficiary() -> Result<(), Box<dyn core::error::Error>> {
-        let ctx = context();
+        let ctx = context_with_funds(MIN_TRANSACTION_COST + L1_DATA_COST);
 
         let mut evm = ctx.build_scroll();
         let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_, _, _>>::new();
@@ -592,7 +598,7 @@ mod tests {
             },
             0..0,
         ));
-        handler.load_accounts(&mut evm)?;
+        handler.pre_execution(&mut evm)?;
         handler.reward_beneficiary(&mut evm, &mut result)?;
 
         let beneficiary = evm.ctx().journal().load_account(BENEFICIARY)?;
@@ -627,18 +633,7 @@ mod tests {
 
     #[test]
     fn test_transaction_pre_execution() -> Result<(), Box<dyn core::error::Error>> {
-        let ctx = context().modify_db_chained(|db| {
-            db.cache.accounts.insert(
-                CALLER,
-                DbAccount {
-                    info: AccountInfo {
-                        balance: MIN_TRANSACTION_COST + U256::ONE,
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                },
-            );
-        });
+        let ctx = context_with_funds(MIN_TRANSACTION_COST + L1_DATA_COST);
 
         let mut evm = ctx.build_scroll();
         let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_, _, _>>::new();


### PR DESCRIPTION
Moves the `L1BlockInfo` fetching into `pre_execution` and adds a test to avoid regression.