### PR TITLE
feat: bump revm to v74

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
+checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
+checksum = "4fa190bfa5340aee544ac831114876fa73bc8da487095b49a5ea153a6a4656ea"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+checksum = "18c35fc4b03ace65001676358ffbbaefe2a2b27ee50fe777c345082c7c888be8"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.14.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
+checksum = "3b7d927aa39ca51545ae4c9cf4bdb2cbc1f6b46ab4b54afc3ed9255f93eedbce"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -1792,8 +1792,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "revm"
-version = "23.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "24.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -1810,8 +1810,8 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "4.0.1"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -1822,8 +1822,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "4.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "5.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -1837,8 +1837,8 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "4.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "5.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -1852,8 +1852,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "4.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "4.0.1"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -1865,8 +1865,8 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "4.0.1"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -1876,8 +1876,8 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "4.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "5.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -1893,8 +1893,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "4.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "5.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -1909,8 +1909,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "19.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "20.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -1920,8 +1920,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "20.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "21.0.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1945,8 +1945,8 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "19.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "19.1.0"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -1968,8 +1968,8 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "4.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth#ffd145a9df51113db02b3d35a6e8b87bbf9b38d8"
+version = "4.0.1"
+source = "git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74#28f83c2759ac9d2d23969a931cf308b375bb6bd4"
 dependencies = [
  "bitflags",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # revm
-revm = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth", default-features = false, features = ["secp256r1", "enable_eip7702"] }
-revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth", default-features = false }
-revm-inspector = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth", default-features = false }
+revm = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74", default-features = false, features = ["secp256r1", "enable_eip7702"] }
+revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74", default-features = false }
+revm-inspector = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74", default-features = false }
 
 # misc
-auto_impl = "1.3.0"
+auto_impl = "1.2.0"
 enumn = { version = "0.1" }
 once_cell = { version = "1.19", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }

--- a/src/precompile/modexp.rs
+++ b/src/precompile/modexp.rs
@@ -52,5 +52,6 @@ fn bernoulli_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
         return Err(PrecompileError::Other("ModexpModOverflow: modexp mod overflow".into()));
     }
 
-    run_inner(input, gas_limit, 200, berlin_gas_calc)
+    const OSAKA: bool = false;
+    run_inner::<_, OSAKA>(input, gas_limit, 200, berlin_gas_calc)
 }


### PR DESCRIPTION
Checked the commits from v73 to v74 and there was no update to any functions related to the `Handler`, so current code is safe.