### PR TITLE
refactor: precompile

### DIFF
--- a/src/precompile/blake2.rs
+++ b/src/precompile/blake2.rs
@@ -1,24 +1,15 @@
 use super::precompile_not_implemented;
 
 use revm::{
-    precompile::{u64_to_address, PrecompileWithAddress},
+    precompile::{blake2, PrecompileWithAddress},
     primitives::Address,
 };
 
-// CONSTANTS
-// ================================================================================================
-
-/// The BLAKE2 precompile index.
-const BLAKE2_PRECOMPILE_INDEX: u64 = 9;
-
 /// The BLAKE2 precompile address.
-const BLAKE2_PRECOMPILE_ADDRESS: Address = u64_to_address(BLAKE2_PRECOMPILE_INDEX);
+pub const ADDRESS: Address = blake2::FUN.0;
 
-// BLAKE2 PRECOMPILE
-// ================================================================================================
-
-/// The shanghai BLAKE2 precompile implementation with address.
+/// The BLAKE2 precompile is not implemented in the SHANGHAI hardfork.
 ///
 /// This precompile is not implemented and will return `PrecompileError::Other("Precompile not
 /// implemented".into())`.
-pub const SHANGHAI: PrecompileWithAddress = precompile_not_implemented(BLAKE2_PRECOMPILE_ADDRESS);
+pub const SHANGHAI: PrecompileWithAddress = precompile_not_implemented(ADDRESS);

--- a/src/precompile/hash.rs
+++ b/src/precompile/hash.rs
@@ -1,56 +1,32 @@
 use super::precompile_not_implemented;
 
 use revm::{
-    precompile::{hash::sha256_run, u64_to_address, PrecompileWithAddress},
+    precompile::{hash, PrecompileWithAddress},
     primitives::Address,
 };
 
 pub mod sha256 {
     use super::*;
 
-    // CONSTANTS
-    // ------------------------------------------------------------------------------------------------
+    /// SHA-256 precompile address
+    pub const ADDRESS: Address = hash::SHA256.0;
 
-    /// The SHA256 precompile index.
-    const SHA256_PRECOMPILE_INDEX: u64 = 2;
-
-    /// The SHA256 precompile address.
-    const SHA256_PRECOMPILE_ADDRESS: Address = u64_to_address(SHA256_PRECOMPILE_INDEX);
-
-    // SHA256 SHANGHAI PRECOMPILE
-    // --------------------------------------------------------------------------------------------
-
-    /// The shanghai SHA256 precompile implementation with address.
-    pub const SHA256_SHANGHAI: PrecompileWithAddress =
-        precompile_not_implemented(SHA256_PRECOMPILE_ADDRESS);
-
-    // SHA256 BERNOULLI PRECOMPILE
-    // --------------------------------------------------------------------------------------------
+    /// The SHA256 precompile is not implemented in the Shanghai hardfork.
+    pub const SHANGHAI: PrecompileWithAddress = precompile_not_implemented(ADDRESS);
 
     /// The bernoulli SHA256 precompile implementation with address.
-    pub const SHA256_BERNOULLI: PrecompileWithAddress =
-        PrecompileWithAddress(SHA256_PRECOMPILE_ADDRESS, sha256_run);
+    pub const BERNOULLI: PrecompileWithAddress = PrecompileWithAddress(ADDRESS, hash::sha256_run);
 }
 
 pub mod ripemd160 {
     use super::*;
 
-    // CONSTANTS
-    // --------------------------------------------------------------------------------------------
-
-    /// The RIPEMD160 precompile index.
-    const RIPEMD160_PRECOMPILE_INDEX: u64 = 3;
-
     /// The RIPEMD160 precompile address.
-    const RIPEMD160_PRECOMPILE_ADDRESS: Address = u64_to_address(RIPEMD160_PRECOMPILE_INDEX);
+    pub const ADDRESS: Address = hash::RIPEMD160.0;
 
-    // RIPEMD160 SHANGHAI PRECOMPILE
-    // --------------------------------------------------------------------------------------------
-
-    /// The shanghai RIPEMD160 precompile implementation with address.
+    /// The shanghai RIPEMD160 precompile is not implemented in the Shanghai hardfork.
     ///
     /// This precompile is not implemented and will return `PrecompileError::Other("Precompile not
     /// implemented".into())`.
-    pub const RIPEMD160_SHANGHAI: PrecompileWithAddress =
-        precompile_not_implemented(RIPEMD160_PRECOMPILE_ADDRESS);
+    pub const SHANGHAI: PrecompileWithAddress = precompile_not_implemented(ADDRESS);
 }

--- a/src/precompile/mod.rs
+++ b/src/precompile/mod.rs
@@ -58,8 +58,8 @@ pub(crate) fn pre_bernoulli() -> &'static Precompiles {
 
         precompiles.extend([
             precompile::secp256k1::ECRECOVER,
-            hash::sha256::SHA256_SHANGHAI,
-            hash::ripemd160::RIPEMD160_SHANGHAI,
+            hash::sha256::SHANGHAI,
+            hash::ripemd160::SHANGHAI,
             precompile::identity::FUN,
             modexp::BERNOULLI,
             precompile::bn128::add::ISTANBUL,
@@ -77,7 +77,7 @@ pub(crate) fn bernoulli() -> &'static Precompiles {
     static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
     INSTANCE.get_or_init(|| {
         let mut precompiles = pre_bernoulli().clone();
-        precompiles.extend([hash::sha256::SHA256_BERNOULLI]);
+        precompiles.extend([hash::sha256::BERNOULLI]);
         Box::new(precompiles)
     })
 }
@@ -149,7 +149,7 @@ impl Default for ScrollPrecompileProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::precompile::bn128::pair::BN128_PAIRING_PRECOMPILE_ADDRESS;
+    use crate::precompile::bn128::pair;
     use revm::primitives::hex;
 
     #[test]
@@ -162,12 +162,12 @@ mod tests {
                 .unwrap();
 
         // Euclid version should reject this input
-        let f = euclid().get(&BN128_PAIRING_PRECOMPILE_ADDRESS).expect("precompile exists");
+        let f = euclid().get(&pair::ADDRESS).expect("precompile exists");
         let outcome = f(&input, u64::MAX);
         assert!(outcome.is_err());
 
         // Feynman version should accept this input
-        let f = feynman().get(&BN128_PAIRING_PRECOMPILE_ADDRESS).expect("precompile exists");
+        let f = feynman().get(&pair::ADDRESS).expect("precompile exists");
         let outcome = f(&input, u64::MAX).expect("call succeeds");
         assert_eq!(outcome.bytes, expected);
     }

--- a/src/precompile/modexp.rs
+++ b/src/precompile/modexp.rs
@@ -1,31 +1,20 @@
 use revm::{
     precompile::{
-        modexp::{berlin_gas_calc, run_inner},
-        u64_to_address,
+        modexp::{self, berlin_gas_calc, run_inner},
         utilities::right_pad_with_offset,
         PrecompileError, PrecompileResult, PrecompileWithAddress,
     },
     primitives::{Address, U256},
 };
 
-// CONSTANTS
-// ================================================================================================
-
-/// The MODEXP precompile index.
-const MODEXP_PRECOMPILE_INDEX: u64 = 5;
-
 /// The MODEXP precompile address.
-const MODEXP_PRECOMPILE_ADDRESS: Address = u64_to_address(MODEXP_PRECOMPILE_INDEX);
+pub const ADDRESS: Address = modexp::BYZANTIUM.0;
 
-/// The maximum length of the input for the MODEXP precompile.
-const SCROLL_LEN_LIMIT: U256 = U256::from_limbs([32, 0, 0, 0]);
+/// The maximum length of the input for the MODEXP precompile in BERNOULLI hardfork.
+pub const BERNOULLI_LEN_LIMIT: U256 = U256::from_limbs([32, 0, 0, 0]);
 
-// MODEXP PRECOMPILE
-// ================================================================================================
-
-/// The bernoulli MODEXP precompile implementation with address.
-pub const BERNOULLI: PrecompileWithAddress =
-    PrecompileWithAddress(MODEXP_PRECOMPILE_ADDRESS, bernoulli_run);
+/// The MODEXP precompile with BERNOULLI length limit rule.
+pub const BERNOULLI: PrecompileWithAddress = PrecompileWithAddress(ADDRESS, bernoulli_run);
 
 /// The bernoulli MODEXP precompile implementation.
 ///
@@ -36,19 +25,19 @@ pub const BERNOULLI: PrecompileWithAddress =
 ///   length is greater than 32 bytes.
 /// - `PrecompileError::Other("ModexpModOverflow: modexp mod overflow".into())` if the modulus
 ///   length is greater than 32 bytes.
-fn bernoulli_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
+pub fn bernoulli_run(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let base_len = U256::from_be_bytes(right_pad_with_offset::<32>(input, 0).into_owned());
     let exp_len = U256::from_be_bytes(right_pad_with_offset::<32>(input, 32).into_owned());
     let mod_len = U256::from_be_bytes(right_pad_with_offset::<32>(input, 64).into_owned());
 
     // modexp temporarily only accepts inputs of 32 bytes (256 bits) or less
-    if base_len > SCROLL_LEN_LIMIT {
+    if base_len > BERNOULLI_LEN_LIMIT {
         return Err(PrecompileError::Other("ModexpBaseOverflow: modexp base overflow".into()));
     }
-    if exp_len > SCROLL_LEN_LIMIT {
+    if exp_len > BERNOULLI_LEN_LIMIT {
         return Err(PrecompileError::Other("ModexpExpOverflow: modexp exp overflow".into()));
     }
-    if mod_len > SCROLL_LEN_LIMIT {
+    if mod_len > BERNOULLI_LEN_LIMIT {
         return Err(PrecompileError::Other("ModexpModOverflow: modexp mod overflow".into()));
     }
 


### PR DESCRIPTION
1. removes magic numbers, define `ADDRESS` from revm::precompile crate.
2. re-export constant for reuse.
3. make it consistent with revm crate code style.