### PR TITLE
feat(feynman): load blockhash from history storage

### DIFF
--- a/src/evm.rs
+++ b/src/evm.rs
@@ -24,7 +24,7 @@ impl<CTX: ScrollContextTr, INSP>
         Self(Evm {
             ctx,
             inspector,
-            instruction: ScrollInstructions::new_mainnet(spec),
+            instruction: ScrollInstructions::new_mainnet(),
             precompiles: ScrollPrecompileProvider::new_with_spec(spec),
         })
     }

--- a/src/l1block.rs
+++ b/src/l1block.rs
@@ -211,23 +211,23 @@ impl L1BlockInfo {
 
         let exec_scalar = self
             .l1_commit_scalar
-            .unwrap_or_else(|| panic!("missing exec scalar in spec_id={:?}", spec_id));
+            .unwrap_or_else(|| panic!("missing exec scalar in spec_id={spec_id:?}"));
 
         let compressed_blob_scalar = self
             .l1_blob_scalar
-            .unwrap_or_else(|| panic!("missing l1 blob scalar in spec_id={:?}", spec_id));
+            .unwrap_or_else(|| panic!("missing l1 blob scalar in spec_id={spec_id:?}"));
 
         let l1_blob_base_fee = self
             .l1_blob_base_fee
-            .unwrap_or_else(|| panic!("missing l1 blob base fee in spec_id={:?}", spec_id));
+            .unwrap_or_else(|| panic!("missing l1 blob base fee in spec_id={spec_id:?}"));
 
         let penalty_threshold = self
             .penalty_threshold
-            .unwrap_or_else(|| panic!("missing penalty threshold in spec_id={:?}", spec_id));
+            .unwrap_or_else(|| panic!("missing penalty threshold in spec_id={spec_id:?}"));
 
         let penalty_factor = self
             .penalty_factor
-            .unwrap_or_else(|| panic!("missing penalty factor in spec_id={:?}", spec_id));
+            .unwrap_or_else(|| panic!("missing penalty factor in spec_id={spec_id:?}"));
 
         let tx_size = U256::from(input.len());
 
@@ -261,7 +261,7 @@ impl L1BlockInfo {
             self.calculate_tx_l1_cost_curie(input, spec_id)
         } else {
             let compression_ratio = compression_ratio.unwrap_or_else(|| {
-                panic!("compression ratio should be set in spec_id={:?}", spec_id)
+                panic!("compression ratio should be set in spec_id={spec_id:?}")
             });
             self.calculate_tx_l1_cost_feynman(input, spec_id, compression_ratio)
         };


### PR DESCRIPTION
The prover needs access to the block hashes. Since these are already present in state starting from Feynman, it is easiest to implement `blockhash` as `sload`.