### PR TITLE
feat: override `difficulty` opcode to always return zero

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -72,7 +72,7 @@ where
 /// - `DIFFICULTY`
 pub fn make_scroll_instruction_table<WIRE: InterpreterTypes, HOST: ScrollContextTr>(
 ) -> InstructionTable<WIRE, HOST> {
-    let mut table: [fn(InstructionContext<'_, HOST, WIRE>); 256] = instruction_table::<WIRE, HOST>();
+    let mut table = instruction_table::<WIRE, HOST>();
 
     // override the instructions
     table[opcode::BLOCKHASH as usize] = blockhash::<WIRE, HOST>;

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -16,8 +16,7 @@ use std::rc::Rc;
 
 const HISTORY_STORAGE_ADDRESS: Address = address!("0x0000F90827F1C53a10cb7A02335B175320002935");
 const HISTORY_SERVE_WINDOW: u64 = 8191;
-// const DIFFICULTY: U256 = U256::ZERO;
-const DIFFICULTY: U256 = U256::from_limbs([1233, 0, 0, 0]);
+const DIFFICULTY: U256 = U256::ZERO;
 
 /// Holds the EVM instruction table for Scroll.
 pub struct ScrollInstructions<WIRE: InterpreterTypes, HOST> {


### PR DESCRIPTION
This PR overrides `difficulty` opcode to always return zero. 

corresponding issue: https://github.com/scroll-tech/scroll-revm/issues/56