### PR TITLE
feat(l1 message): nonce, code and base fee checks

### DIFF
--- a/src/tests/l1_message.rs
+++ b/src/tests/l1_message.rs
@@ -46,7 +46,7 @@ fn test_l1_message_load_accounts() -> Result<(), Box<dyn core::error::Error>> {
 }
 
 #[test]
-fn test_l1_message_should_deduct_caller() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_should_not_deduct_caller() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();
@@ -86,7 +86,7 @@ fn test_l1_message_last_frame_result() -> Result<(), Box<dyn core::error::Error>
 }
 
 #[test]
-fn test_l1_message_refund() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_should_not_refund() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();
@@ -107,7 +107,7 @@ fn test_l1_message_refund() -> Result<(), Box<dyn core::error::Error>> {
 }
 
 #[test]
-fn test_l1_message_should_reward_beneficiary() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_should_not_reward_beneficiary() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();

--- a/src/tests/l1_message.rs
+++ b/src/tests/l1_message.rs
@@ -20,7 +20,7 @@ use revm::{
 use revm_primitives::U256;
 
 #[test]
-fn test_validate_lacking_funds_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_validate_lacking_funds() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
     let mut evm = ctx.build_scroll();
     let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_>>::new();
@@ -32,7 +32,7 @@ fn test_validate_lacking_funds_l1_message() -> Result<(), Box<dyn core::error::E
 }
 
 #[test]
-fn test_load_account_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_load_accounts() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
     let mut evm = ctx.build_scroll();
     let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_>>::new();
@@ -46,7 +46,7 @@ fn test_load_account_l1_message() -> Result<(), Box<dyn core::error::Error>> {
 }
 
 #[test]
-fn test_deduct_caller_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_should_deduct_caller() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();
@@ -64,7 +64,7 @@ fn test_deduct_caller_l1_message() -> Result<(), Box<dyn core::error::Error>> {
 }
 
 #[test]
-fn test_last_frame_result_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_last_frame_result() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();
@@ -86,7 +86,7 @@ fn test_last_frame_result_l1_message() -> Result<(), Box<dyn core::error::Error>
 }
 
 #[test]
-fn test_refund_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_refund() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();
@@ -107,7 +107,7 @@ fn test_refund_l1_message() -> Result<(), Box<dyn core::error::Error>> {
 }
 
 #[test]
-fn test_reward_beneficiary_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_should_reward_beneficiary() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| tx.base.tx_type = L1_MESSAGE_TYPE);
 
     let mut evm = ctx.build_scroll();
@@ -129,7 +129,7 @@ fn test_reward_beneficiary_l1_message() -> Result<(), Box<dyn core::error::Error
 }
 
 #[test]
-fn test_should_revert_with_out_of_funds_l1_message() -> Result<(), Box<dyn core::error::Error>> {
+fn test_l1_message_should_revert_with_out_of_funds() -> Result<(), Box<dyn core::error::Error>> {
     let ctx = context().modify_tx_chained(|tx| {
         tx.base.tx_type = L1_MESSAGE_TYPE;
         tx.base.value = U256::ONE;
@@ -147,6 +147,43 @@ fn test_should_revert_with_out_of_funds_l1_message() -> Result<(), Box<dyn core:
             reason: HaltReason::OutOfFunds
         }
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_l1_message_should_pass_validation() -> Result<(), Box<dyn core::error::Error>> {
+    let ctx = context()
+        .modify_tx_chained(|tx| {
+            tx.base.tx_type = L1_MESSAGE_TYPE;
+            tx.base.value = U256::ONE;
+            tx.base.gas_price = 0;
+        })
+        // set the base fee of the block above the L1 message gas price to check it passes.
+        .modify_block_chained(|block| block.basefee = 100);
+    let mut evm = ctx.build_scroll();
+    let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_>>::new();
+
+    handler.validate(&mut evm)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_l1_message_should_pass_pre_execution() -> Result<(), Box<dyn core::error::Error>> {
+    let ctx = context()
+        .modify_tx_chained(|tx| {
+            tx.base.tx_type = L1_MESSAGE_TYPE;
+        })
+        // set the caller nonce to 1 and check pre execution passes.
+        .modify_journal_chained(|journal| {
+            let caller = journal.load_account(CALLER).unwrap();
+            caller.data.info.nonce += 1;
+        });
+    let mut evm = ctx.build_scroll();
+    let handler = ScrollHandler::<_, EVMError<_>, EthFrame<_>>::new();
+
+    handler.pre_execution(&mut evm)?;
 
     Ok(())
 }


### PR DESCRIPTION
Makes the following update to the L1 message validation rules:
- Nonce check is explicitly removed by removing the `validate_account_nonce_and_code` call. 
- Base fee check was already skipped [here](https://github.com/scroll-tech/revm/blob/1477307e9ba3bb7dfb5403475ea226410bbf5354/crates/handler/src/validation.rs#L225).
- Explicitly perform EIP-3607 checks.